### PR TITLE
Update OPS config to point at the dev version of the site template

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -24,7 +24,7 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
-      "branch": "master",
+      "branch": "develop",
       "branch_mapping": {}
     }
   ]


### PR DESCRIPTION
Gets you the latest version of our templates, good for sandbox/testing work. We can revert this before you go live.