### PR TITLE
Correct broken link to Github sample code

### DIFF
--- a/aspnet/aspnetcore/mvc/models/formatting.md
+++ b/aspnet/aspnetcore/mvc/models/formatting.md
@@ -7,7 +7,7 @@ By [Steve Smith](http://ardalis.com)
 
 ASP.NET Core MVC has built-in support for formatting response data, using fixed formats or in response to client specifications.
 
-[View or download sample from GitHub](https://github.com/aspnet/Docs/tree/master/mvc/models/formatting/sample).
+[View or download sample from GitHub](https://github.com/aspnet/Docs/tree/master/aspnet/mvc/models/formatting/sample).
 
 ## Format-Specific Action Results
 


### PR DESCRIPTION
Link to sample code on Github was broken, link now corrected.