### PR TITLE
Update code snippet to match describing text

### DIFF
--- a/aspnet/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopyEmail.cshtml
+++ b/aspnet/aspnetcore/mvc/views/tag-helpers/authoring/sample/AuthoringTagHelpers/src/AuthoringTagHelpers/Views/_ViewImportsCopyEmail.cshtml
@@ -1,3 +1,3 @@
 ﻿@using AuthoringTagHelpers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper "AuthoringTagHelpers.TagHelpers.EmailTagHelper, AuthoringTagHelpers"
+@addTagHelper "*, AuthoringTagHelpers"


### PR DESCRIPTION
The tutorial copy below this snippet mentions "The code above used the wildcard syntax," but as written it does not. Fixed the code snippet to display correct usage of the wildcard syntax.